### PR TITLE
Update plugin to allow the users to provide where the rabbitmq will g…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,19 @@ A maven plugin that downloads, install and configures a RabbitMQ instance within
 
 ## Example Usage
 
-Below is an example configuration for the plugin. You can add exchanges, queues and their binding in the configuration section.
+Below is an example configuration for the plugin. You can specify the port, rabbitmq version, rabbit mq install directory, and if you would like rabbitmq removed on stop. You can add exchanges, queues and their binding in the configuration section.
 
 ```xml
 <plugin>
-    <groupId>com.github.iesen</groupId>
+    <groupId>com.github.kohlsj</groupId>
     <artifactId>rabbitmq-maven-plugin</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.10</version>
     <configuration>
         <detached>true</detached>
+        <port>5672</port>
+        <installDirectory>target/rabbitmq</installDirectory>
+        <cleanUpRabbit>true</cleanUpRabbit>
+        <version>3.6.9</version>
         <exchanges>
             <exchange>
                 <name>myexchange</name>
@@ -35,10 +39,17 @@ Below is an example configuration for the plugin. You can add exchanges, queues 
     </configuration>
 </plugin>
 ```
+##Configuration Values:
+
+installDirectory : default is ~/.rabbitmq_maven_plugin (.rabbitmq_maven_plugin will append to the installDirectory if specified) <br>
+cleanUpRabbit : will remove directory specified by installDirectory + .rabbitmq_maven_plugin<br>
+port : specify the port that rabbitmq will be ran on.<br>
+version : rabbitMq version. <br>
+alwaysRestart : if rmq is already running this specifies whether or not to restart during mvn rabbitmq:start
 
 ##More Information
 
-The plugin first checks if RabbitMQ is installed by this plugin before. If not, installs RabbitMQ to the home folder.
+The plugin first checks if RabbitMQ is installed at the specified directory before, if not then it will install it
 (also installs Erlang runtime if OS is Windows). Just after installation it enables the management plugin and applies
 the settings specified in the plugin configuration.
 
@@ -46,7 +57,7 @@ the settings specified in the plugin configuration.
 
 Windows and Mac OS is supported.
 
-Linux is supported but withouth erlang support.
+Linux is supported but without erlang support.
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.jkirsch</groupId>
+    <groupId>com.cdk.dmg.plugin</groupId>
     <artifactId>rabbitmq-maven-plugin</artifactId>
-    <version>0.1.9</version>
+    <version>0.1.10</version>
     <packaging>maven-plugin</packaging>
 
     <name>RabbitMQ Maven Plugin</name>
@@ -32,6 +33,13 @@
             <organization>Ooyala</organization>
             <organizationUrl>www.ooyala.com</organizationUrl>
             <timezone>Europe/Stockholm</timezone>
+        </developer>
+        <developer>
+            <name>Jeff Kohls</name>
+            <email>jeffkohls@comcast.net</email>
+            <organization>CDK Global</organization>
+            <organizationUrl>www.cdkglobal.com</organizationUrl>
+            <timezone>US/Seattle</timezone>
         </developer>
     </developers>
 
@@ -204,11 +212,11 @@
             <artifactId>commons-compress</artifactId>
             <version>${commons.compress.version}</version>
         </dependency>
-	<dependency>
-	  <groupId>org.tukaani</groupId>
-	  <artifactId>xz</artifactId>
-	  <version>${org.tukaani.version}</version>
-	</dependency>
+        <dependency>
+            <groupId>org.tukaani</groupId>
+            <artifactId>xz</artifactId>
+            <version>${org.tukaani.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -306,10 +314,10 @@
     </distributionManagement>
 
     <scm>
-        <connection>scm:git:https://github.com/iesen/rabbitmq-maven-plugin.git</connection>
-        <developerConnection>scm:git:https://github.com/iesen/rabbitmq-maven-plugin.git</developerConnection>
-        <url>git@github.com:iesen/rabbitmq-maven-plugin.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <connection>scm:git:https://github.com/Chancell0r/rabbitmq-maven-plugin.git</connection>
+        <developerConnection>scm:git:https://github.com/Chancell0r/rabbitmq-maven-plugin.git</developerConnection>
+        <url>git@github.com:Chancell0r/rabbitmq-maven-plugin.git</url>
+        <tag>HEAD</tag>
+    </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.cdk.dmg.plugin</groupId>
+    <groupId>com.github.kohlsj</groupId>
     <artifactId>rabbitmq-maven-plugin</artifactId>
     <version>0.1.10</version>
     <packaging>maven-plugin</packaging>

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/RabbitMQConstants.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/RabbitMQConstants.java
@@ -1,24 +1,61 @@
 package com.github.iesen.rabbitmq.plugin;
 
-import org.apache.commons.lang3.SystemUtils;
-
 import java.io.File;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 /**
  */
 public class RabbitMQConstants {
 
+    private static final String RABBIT_MQ_PLUGIN_DIR = ".rabbitmq_maven_plugin";
+
+    private static final String RABBITMQ_PARENT_DIR = SystemUtils.getUserHome() + File.separator + RABBIT_MQ_PLUGIN_DIR;
+
     public static final String RABBITMQ_DEFAULT_PORT = "5672";
-    public static final String RABBITMQ_VERSION = "3.6.9";
-    public static final String RABBITMQ_PARENT_DIR = SystemUtils.getUserHome() + File.separator + ".rabbitmq_maven_plugin";
-    public static final String RABBITMQ_HOME = RABBITMQ_PARENT_DIR + File.separator + "rabbitmq_server-" + RABBITMQ_VERSION;
+
+    public static final String RABBITMQ_DEFAULT_VERSION = "3.6.9";
+
     public static final String ERLANG_HOME_WIN = System.getenv("ProgramFiles") + File.separator + "erl8.2";
     public static final String ERLANG_INSTALLER_URL = "http://erlang.org/download/otp_win64_19.2.exe";
     public static final String ERLANG_INSTALLER_FILE_NAME = "otp_win64_19.2.exe";
 
+    private static RabbitMQConstants rabbitMqConstants;
 
-    private RabbitMQConstants() {
+    private final String rabbitMqVersion;
 
+    private final String rabbitMqParentDir;
+
+    private final String rabbitMqHome;
+
+    private RabbitMQConstants(String rabbitMqVersion, String rabbitMqParentDir, String rabbitMqHome) {
+        this.rabbitMqVersion = rabbitMqVersion;
+        this.rabbitMqParentDir = rabbitMqParentDir;
+        this.rabbitMqHome = rabbitMqHome;
     }
 
+    public static void createInstance( String rabbitMqVersion, String rabbitMqParentDir){
+        if(rabbitMqConstants == null){
+            String rabbitMqParentDirActual = StringUtils.isEmpty(rabbitMqParentDir) ? RABBITMQ_PARENT_DIR : rabbitMqParentDir + RABBIT_MQ_PLUGIN_DIR;
+            String rabbitMqHome = rabbitMqParentDirActual + File.separator + "rabbitmq_server-" + rabbitMqVersion;
+            rabbitMqConstants = new RabbitMQConstants(rabbitMqVersion, rabbitMqParentDirActual, rabbitMqHome);
+        }
+    }
+
+    public static RabbitMQConstants getInstance(){
+        return rabbitMqConstants;
+    }
+
+    public String getRabbitMqVersion() {
+        return rabbitMqVersion;
+    }
+
+    public String getRabbitMqParentDir() {
+        return rabbitMqParentDir;
+    }
+
+    public String getRabbitMqHome() {
+        return rabbitMqHome;
+    }
 }

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/RabbitManagerFactory.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/RabbitManagerFactory.java
@@ -1,8 +1,9 @@
 package com.github.iesen.rabbitmq.plugin;
 
-import com.github.iesen.rabbitmq.plugin.manager.LinuxRabbitManager;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.plugin.logging.Log;
+
+import com.github.iesen.rabbitmq.plugin.manager.LinuxRabbitManager;
 import com.github.iesen.rabbitmq.plugin.manager.MacRabbitManager;
 import com.github.iesen.rabbitmq.plugin.manager.RabbitManager;
 import com.github.iesen.rabbitmq.plugin.manager.WindowsRabbitManager;

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/api/RabbitMQRestClientImpl.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/api/RabbitMQRestClientImpl.java
@@ -1,6 +1,8 @@
 package com.github.iesen.rabbitmq.plugin.api;
 
-import com.github.iesen.rabbitmq.plugin.api.model.BindingResource;
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
@@ -8,17 +10,17 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
-import retrofit.RequestInterceptor;
-import retrofit.RestAdapter;
-import retrofit.client.Response;
+
+import com.github.iesen.rabbitmq.plugin.api.model.BindingResource;
 import com.github.iesen.rabbitmq.plugin.api.model.ExchangeResource;
 import com.github.iesen.rabbitmq.plugin.api.model.QueueResource;
 import com.github.iesen.rabbitmq.plugin.mojo.parameter.Binding;
 import com.github.iesen.rabbitmq.plugin.mojo.parameter.Exchange;
 import com.github.iesen.rabbitmq.plugin.mojo.parameter.Queue;
 
-import java.io.IOException;
-import java.util.List;
+import retrofit.RequestInterceptor;
+import retrofit.RestAdapter;
+import retrofit.client.Response;
 
 /**
  * RabbitMQ Management operations implementation
@@ -83,7 +85,6 @@ public class RabbitMQRestClientImpl implements RabbitMQRestClient {
                 }
             }
         }
-
     }
 
     private boolean waitForManagementToStart() throws MojoExecutionException {

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/manager/LinuxRabbitManager.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/manager/LinuxRabbitManager.java
@@ -1,66 +1,59 @@
 package com.github.iesen.rabbitmq.plugin.manager;
 
-import static com.github.iesen.rabbitmq.plugin.RabbitMQConstants.RABBITMQ_HOME;
-import static com.github.iesen.rabbitmq.plugin.RabbitMQConstants.RABBITMQ_PARENT_DIR;
-import static com.github.iesen.rabbitmq.plugin.RabbitMQConstants.RABBITMQ_VERSION;
+import java.io.File;
+import java.io.IOException;
 
-import com.google.common.collect.Lists;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.List;
+import com.github.iesen.rabbitmq.plugin.RabbitMQConstants;
 
 /**
  */
 public class LinuxRabbitManager extends MacRabbitManager {
 
     private static final int BUFFER = 2048;
+
     private final Log log;
 
-    public LinuxRabbitManager(Log log) {
+    public LinuxRabbitManager(final Log log) {
         super(log);
         this.log = log;
     }
 
     @Override
-    public boolean rabbitExtracted() {
-        File rabbitHome = new File(RABBITMQ_HOME);
-        log.info("Checking " + rabbitHome.getAbsolutePath());
-        boolean exists = rabbitHome.exists();
-        log.info("RabbitMQ " + (exists ? "found" : "not found"));
-        return exists;
-    }
-
-    @Override
     public void extractServer() throws MojoExecutionException {
         try {
-            String rabbitDownloadUrl = "https://www.rabbitmq.com/releases/rabbitmq-server/v" + RABBITMQ_VERSION +
-               "/rabbitmq-server-generic-unix-" + RABBITMQ_VERSION + ".tar.xz";
+            final RabbitMQConstants rabbitMQConstants = RabbitMQConstants.getInstance();
+            final String rabbitDownloadUrl =
+                    "https://www.rabbitmq.com/releases/rabbitmq-server/v" + rabbitMQConstants.getRabbitMqVersion() +
+                    "/rabbitmq-server-generic-unix-" + rabbitMQConstants.getRabbitMqVersion() + ".tar.xz";
             log.debug("Downloading rabbitmq from " + rabbitDownloadUrl);
-            FileUtils.download(rabbitDownloadUrl, RABBITMQ_PARENT_DIR + File.separator + "rabbitmq-server-mac-standalone-" + RABBITMQ_VERSION + ".tar.xz");
+            FileUtils.download(rabbitDownloadUrl,
+                    rabbitMQConstants.getRabbitMqParentDir() + File.separator + "rabbitmq-server-mac-standalone-" +
+                    rabbitMQConstants.getRabbitMqVersion() + ".tar.xz");
             log.debug("Extracting downloaded files");
-            FileUtils.extractTarXz(RABBITMQ_PARENT_DIR + File.separator + "rabbitmq-server-mac-standalone-" + RABBITMQ_VERSION + ".tar.xz", RABBITMQ_PARENT_DIR);
+            FileUtils.extractTarXz(
+                    rabbitMQConstants.getRabbitMqParentDir() + File.separator + "rabbitmq-server-mac-standalone-" +
+                    rabbitMQConstants.getRabbitMqVersion() + ".tar.xz", rabbitMQConstants.getRabbitMqParentDir());
             // Give permissions
-            ProcessBuilder permissionProcess = new ProcessBuilder("/bin/chmod", "-R", "777", RABBITMQ_PARENT_DIR);
+            final ProcessBuilder permissionProcess = new ProcessBuilder("/bin/chmod", "-R", "777", rabbitMQConstants.getRabbitMqParentDir());
             log.debug("Permission command " + permissionProcess.command());
-            Process permission = permissionProcess.start();
+            final Process permission = permissionProcess.start();
             permission.waitFor();
             // Enable management
-            ProcessBuilder managementEnabler = new ProcessBuilder(RABBITMQ_HOME + File.separator + "sbin" + File.separator + "rabbitmq-plugins", "enable", "rabbitmq_management");
+            final ProcessBuilder managementEnabler = new ProcessBuilder(
+                    rabbitMQConstants.getRabbitMqHome() + File.separator + "sbin" + File.separator +
+                    "rabbitmq-plugins", "enable", "rabbitmq_management");
             log.debug("Enable management " + managementEnabler.command());
-            Process mgmt = managementEnabler.start();
+            final Process mgmt = managementEnabler.start();
             mgmt.waitFor();
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new MojoExecutionException("Error extracting server", e);
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             throw new MojoExecutionException("Error executing process", e);
         }
     }
-
 
     @Override
     public void installErlang() throws MojoExecutionException {
@@ -69,15 +62,15 @@ public class LinuxRabbitManager extends MacRabbitManager {
 
     @Override
     public boolean isErlangInstalled() throws MojoExecutionException {
-        ProcessBuilder permissionProcess = new ProcessBuilder("erl","-version");
+        final ProcessBuilder permissionProcess = new ProcessBuilder("erl", "-version");
         log.debug("Erlang version command " + permissionProcess.command());
         Process permission = null;
         try {
             permission = permissionProcess.start();
             permission.waitFor();
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new MojoExecutionException("Erlang is not installed", e);
-        } catch (InterruptedException e){
+        } catch (final InterruptedException e) {
             throw new MojoExecutionException("Erlang is not installed", e);
         }
         return true;

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/manager/MacRabbitManager.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/manager/MacRabbitManager.java
@@ -1,16 +1,16 @@
 package com.github.iesen.rabbitmq.plugin.manager;
 
-import com.google.common.collect.Lists;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.logging.Log;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 
-import static com.github.iesen.rabbitmq.plugin.RabbitMQConstants.*;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+
+import com.github.iesen.rabbitmq.plugin.RabbitMQConstants;
+import com.google.common.collect.Lists;
 
 /**
  */
@@ -25,7 +25,8 @@ public class MacRabbitManager implements RabbitManager {
 
     @Override
     public boolean rabbitExtracted() {
-        File rabbitHome = new File(RABBITMQ_HOME);
+        RabbitMQConstants rabbitMQConstants = RabbitMQConstants.getInstance();
+        File rabbitHome = new File(rabbitMQConstants.getRabbitMqHome());
         log.info("Checking " + rabbitHome.getAbsolutePath());
         boolean exists = rabbitHome.exists();
         log.info("RabbitMQ " + (exists ? "found" : "not found"));
@@ -35,18 +36,19 @@ public class MacRabbitManager implements RabbitManager {
     @Override
     public void extractServer() throws MojoExecutionException {
         try {
-            String rabbitDownloadUrl = "https://www.rabbitmq.com/releases/rabbitmq-server/v" + RABBITMQ_VERSION + "/rabbitmq-server-mac-standalone-" + RABBITMQ_VERSION + ".tar.xz";
+            RabbitMQConstants rabbitMQConstants = RabbitMQConstants.getInstance();
+            String rabbitDownloadUrl = "https://www.rabbitmq.com/releases/rabbitmq-server/v" + rabbitMQConstants.getRabbitMqVersion() + "/rabbitmq-server-mac-standalone-" + rabbitMQConstants.getRabbitMqVersion() + ".tar.xz";
             log.debug("Downloading rabbitmq from " + rabbitDownloadUrl);
-            FileUtils.download(rabbitDownloadUrl, RABBITMQ_PARENT_DIR + File.separator + "rabbitmq-server-mac-standalone-" + RABBITMQ_VERSION + ".tar.xz");
+            FileUtils.download(rabbitDownloadUrl, rabbitMQConstants.getRabbitMqParentDir() + File.separator + "rabbitmq-server-mac-standalone-" + rabbitMQConstants.getRabbitMqVersion() + ".tar.xz");
             log.debug("Extracting downloaded files");
-            FileUtils.extractTarXz(RABBITMQ_PARENT_DIR + File.separator + "rabbitmq-server-mac-standalone-" + RABBITMQ_VERSION + ".tar.xz", RABBITMQ_PARENT_DIR);
+            FileUtils.extractTarXz(rabbitMQConstants.getRabbitMqParentDir() + File.separator + "rabbitmq-server-mac-standalone-" + rabbitMQConstants.getRabbitMqVersion() + ".tar.xz", rabbitMQConstants.getRabbitMqParentDir());
             // Give permissions
-            ProcessBuilder permissionProcess = new ProcessBuilder("/bin/chmod", "-R", "777", RABBITMQ_PARENT_DIR);
+            ProcessBuilder permissionProcess = new ProcessBuilder("/bin/chmod", "-R", "777", rabbitMQConstants.getRabbitMqParentDir());
             log.debug("Permission command " + permissionProcess.command());
             Process permission = permissionProcess.start();
             permission.waitFor();
             // Enable management
-            ProcessBuilder managementEnabler = new ProcessBuilder(RABBITMQ_HOME + File.separator + "sbin" + File.separator + "rabbitmq-plugins", "enable", "rabbitmq_management");
+            ProcessBuilder managementEnabler = new ProcessBuilder(rabbitMQConstants.getRabbitMqHome() + File.separator + "sbin" + File.separator + "rabbitmq-plugins", "enable", "rabbitmq_management");
             log.debug("Enable management " + managementEnabler.command());
             Process mgmt = managementEnabler.start();
             mgmt.waitFor();
@@ -58,13 +60,29 @@ public class MacRabbitManager implements RabbitManager {
     }
 
     @Override
+    public void removeRabbitMq() throws MojoExecutionException {
+        try {
+            RabbitMQConstants rabbitMQConstants = RabbitMQConstants.getInstance();
+            ProcessBuilder removeRabbitMqProcess = new ProcessBuilder("/bin/rm", "-rf", rabbitMQConstants.getRabbitMqParentDir());
+            log.debug("Permission command " + removeRabbitMqProcess.command());
+            Process permission = removeRabbitMqProcess.start();
+            permission.waitFor();
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error extracting server", e);
+        } catch (InterruptedException e) {
+            throw new MojoExecutionException("Error executing process", e);
+        }
+    }
+
+    @Override
     public boolean isRabbitRunning() throws MojoExecutionException {
         try {
-            String rabbitctlPath = RABBITMQ_HOME + File.separator + "sbin" + File.separator + "rabbitmqctl";
+            RabbitMQConstants rabbitMQConstants = RabbitMQConstants.getInstance();
+            String rabbitctlPath = rabbitMQConstants.getRabbitMqHome() + File.separator + "sbin" + File.separator + "rabbitmqctl";
             if (!(new File(rabbitctlPath).exists())) {
                 throw new MojoExecutionException("RabbitMQ has not started yet");
             }
-            ProcessBuilder statusProcessBuilder = new ProcessBuilder(RABBITMQ_HOME + File.separator + "sbin" + File.separator + "rabbitmqctl", "status");
+            ProcessBuilder statusProcessBuilder = new ProcessBuilder(rabbitMQConstants.getRabbitMqHome() + File.separator + "sbin" + File.separator + "rabbitmqctl", "status");
             log.info(statusProcessBuilder.command().toString());
             Process statusProcess = statusProcessBuilder.start();
             String statusLine;
@@ -84,7 +102,8 @@ public class MacRabbitManager implements RabbitManager {
     @Override
     public void stop() throws MojoExecutionException {
         try {
-            String rabbitctlPath = RABBITMQ_HOME + File.separator + "sbin" + File.separator + "rabbitmqctl";
+            RabbitMQConstants rabbitMQConstants = RabbitMQConstants.getInstance();
+            String rabbitctlPath = rabbitMQConstants.getRabbitMqHome() + File.separator + "sbin" + File.separator + "rabbitmqctl";
             if (!(new File(rabbitctlPath).exists())) {
                 throw new MojoExecutionException("RabbitMQ is not started");
             }
@@ -107,7 +126,8 @@ public class MacRabbitManager implements RabbitManager {
     @Override
     public void start(String port, boolean detached) throws MojoExecutionException {
         try {
-            List<String> startCommand = Lists.newArrayList(RABBITMQ_HOME + File.separator + "sbin" + File.separatorChar + "rabbitmq-server");
+            RabbitMQConstants rabbitMQConstants = RabbitMQConstants.getInstance();
+            List<String> startCommand = Lists.newArrayList(rabbitMQConstants.getRabbitMqHome() + File.separator + "sbin" + File.separatorChar + "rabbitmq-server");
             if (detached) {
                 startCommand.add("-detached");
             }
@@ -119,7 +139,7 @@ public class MacRabbitManager implements RabbitManager {
             log.debug("Start result: " + result);
             if(isRabbitRunning())
                log.info("RabbitMQ Running on: " + port);
-            List<String> managementCommand= Lists.newArrayList(RABBITMQ_HOME + File.separator + "sbin" + File.separator + "rabbitmq-plugins", "enable",
+            List<String> managementCommand= Lists.newArrayList(rabbitMQConstants.getRabbitMqHome() + File.separator + "sbin" + File.separator + "rabbitmq-plugins", "enable",
                "rabbitmq_management");
             ProcessBuilder managementEnabler = new ProcessBuilder(managementCommand);
             log.info("Enable management" + managementEnabler.command());

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/manager/RabbitManager.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/manager/RabbitManager.java
@@ -10,6 +10,8 @@ public interface RabbitManager {
 
     void extractServer() throws MojoExecutionException;
 
+    void removeRabbitMq() throws MojoExecutionException;
+
     boolean isRabbitRunning() throws MojoExecutionException;
 
     void stop() throws MojoExecutionException;

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/mojo/StartRabbitMojo.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/mojo/StartRabbitMojo.java
@@ -1,20 +1,20 @@
 package com.github.iesen.rabbitmq.plugin.mojo;
 
+import java.util.List;
 
-import com.github.iesen.rabbitmq.plugin.mojo.parameter.Queue;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+
 import com.github.iesen.rabbitmq.plugin.RabbitMQConstants;
 import com.github.iesen.rabbitmq.plugin.RabbitManagerFactory;
 import com.github.iesen.rabbitmq.plugin.api.RabbitMQRestClient;
 import com.github.iesen.rabbitmq.plugin.api.RabbitMQRestClientImpl;
 import com.github.iesen.rabbitmq.plugin.manager.RabbitManager;
 import com.github.iesen.rabbitmq.plugin.mojo.parameter.Exchange;
-
-import java.util.List;
+import com.github.iesen.rabbitmq.plugin.mojo.parameter.Queue;
 
 /**
  * Starts rabbitmq and configures exchanges, queues and bindings.
@@ -23,34 +23,52 @@ import java.util.List;
 @Mojo(name = "start")
 public class StartRabbitMojo extends AbstractMojo {
 
+    @Parameter(defaultValue = "true")
+    private boolean alwaysRestart = true;
+
     @Parameter(defaultValue = RabbitMQConstants.RABBITMQ_DEFAULT_PORT)
     private String port;
+
     @Parameter(defaultValue = "true")
     private boolean detached;
+
+    @Parameter
+    private String installDirectory;
+
+    @Parameter(defaultValue = RabbitMQConstants.RABBITMQ_DEFAULT_VERSION)
+    private String version;
+
     @Parameter
     private List<Exchange> exchanges;
+
     @Parameter
     private List<Queue> queues;
+
     private RabbitMQRestClient rabbitMQRestClient;
 
     public StartRabbitMojo() {
         rabbitMQRestClient = new RabbitMQRestClientImpl("http://localhost:15672", "guest", "guest", getLog());
     }
 
+    @Override
     public void execute() throws MojoExecutionException {
-        RabbitManager manager = RabbitManagerFactory.create(getLog());
+        RabbitMQConstants.createInstance(version, installDirectory);
+        final RabbitManager manager = RabbitManagerFactory.create(getLog());
         if (!manager.rabbitExtracted()) {
             manager.extractServer();
         }
         if (!manager.isErlangInstalled()) {
             manager.installErlang();
         }
-        if (manager.isRabbitRunning()) {
+        if (manager.isRabbitRunning() && alwaysRestart) {
             getLog().info("RabbitMQ already running...");
             getLog().info("Restarting RabbitMQ...");
             manager.stop();
         }
-        manager.start(port, detached);
+
+        if (!manager.isRabbitRunning()) {
+            manager.start(port, detached);
+        }
         // Configure exchanges and queues
         if (exchanges != null) {
             getLog().debug("Exchanges : " + ToStringBuilder.reflectionToString(exchanges));
@@ -62,15 +80,15 @@ public class StartRabbitMojo extends AbstractMojo {
         }
     }
 
-    public void setRabbitMQRestClient(RabbitMQRestClient rabbitMQRestClient) {
+    public void setRabbitMQRestClient(final RabbitMQRestClient rabbitMQRestClient) {
         this.rabbitMQRestClient = rabbitMQRestClient;
     }
 
-    public void setExchanges(List<Exchange> exchanges) {
+    public void setExchanges(final List<Exchange> exchanges) {
         this.exchanges = exchanges;
     }
 
-    public void setQueues(List<Queue> queues) {
+    public void setQueues(final List<Queue> queues) {
         this.queues = queues;
     }
 }

--- a/src/main/java/com/github/iesen/rabbitmq/plugin/mojo/StopRabbitMojo.java
+++ b/src/main/java/com/github/iesen/rabbitmq/plugin/mojo/StopRabbitMojo.java
@@ -1,9 +1,11 @@
 package com.github.iesen.rabbitmq.plugin.mojo;
 
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.github.iesen.rabbitmq.plugin.RabbitMQConstants;
 import com.github.iesen.rabbitmq.plugin.RabbitManagerFactory;
 import com.github.iesen.rabbitmq.plugin.manager.RabbitManager;
 
@@ -13,10 +15,23 @@ import com.github.iesen.rabbitmq.plugin.manager.RabbitManager;
 @Mojo(name = "stop")
 public class StopRabbitMojo extends AbstractMojo {
 
+    @Parameter(defaultValue = "false")
+    private boolean cleanUpRabbit;
+
+    @Parameter
+    private String installDirectory;
+
+    @Parameter(defaultValue = RabbitMQConstants.RABBITMQ_DEFAULT_PORT)
+    private String port;
+
+    @Parameter(defaultValue = RabbitMQConstants.RABBITMQ_DEFAULT_VERSION)
+    private String version;
 
     public void execute() throws MojoExecutionException {
+        RabbitMQConstants.createInstance(version, installDirectory);
         RabbitManager manager = RabbitManagerFactory.create(getLog());
         if (!manager.isRabbitRunning()) {
+            cleanUpRabbit(manager);
             throw new MojoExecutionException("RabbitMQ is not started");
         }
         if (!manager.rabbitExtracted()) {
@@ -24,6 +39,14 @@ public class StopRabbitMojo extends AbstractMojo {
         }
         getLog().info("Stopping RabbitMQ...");
         manager.stop();
+        cleanUpRabbit(manager);
+    }
+
+    private void cleanUpRabbit(RabbitManager manager) throws MojoExecutionException {
+        if(cleanUpRabbit) {
+            getLog().info("Removing RabbitMQ...");
+            manager.removeRabbitMq();
+        }
     }
 
 }

--- a/src/test/java/com/github/iesen/rabbitmq/plugin/mojo/StartRabbitMojoTest.java
+++ b/src/test/java/com/github/iesen/rabbitmq/plugin/mojo/StartRabbitMojoTest.java
@@ -1,7 +1,16 @@
 package com.github.iesen.rabbitmq.plugin.mojo;
 
-import com.github.iesen.rabbitmq.plugin.mojo.StartRabbitMojo;
-import com.google.common.collect.Lists;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.util.List;
+
 import org.apache.maven.plugin.logging.Log;
 import org.junit.Before;
 import org.junit.Test;
@@ -9,27 +18,24 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
 import com.github.iesen.rabbitmq.plugin.RabbitManagerFactory;
 import com.github.iesen.rabbitmq.plugin.api.RabbitMQRestClient;
 import com.github.iesen.rabbitmq.plugin.manager.RabbitManager;
 import com.github.iesen.rabbitmq.plugin.mojo.parameter.Exchange;
 import com.github.iesen.rabbitmq.plugin.mojo.parameter.Queue;
-
-import java.util.List;
-
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
+import com.google.common.collect.Lists;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({RabbitManagerFactory.class, StartRabbitMojo.class})
+@PrepareForTest({ RabbitManagerFactory.class, StartRabbitMojo.class })
 public class StartRabbitMojoTest {
 
     private RabbitManager manager;
+
     private Log log;
+
     private StartRabbitMojo mojo;
+
     private RabbitMQRestClient rabbitMQRestClient;
 
     @Before
@@ -46,6 +52,7 @@ public class StartRabbitMojoTest {
         mojo = new StartRabbitMojo();
         mojo.setLog(log);
         mojo.setRabbitMQRestClient(rabbitMQRestClient);
+
     }
 
     @Test
@@ -58,7 +65,7 @@ public class StartRabbitMojoTest {
         verify(manager).rabbitExtracted();
         verify(manager).extractServer();
         verify(manager).isErlangInstalled();
-        verify(manager).isRabbitRunning();
+        verify(manager, times(2)).isRabbitRunning();
         verify(manager).start(anyString(), anyBoolean());
         verifyNoMoreInteractions(manager);
     }
@@ -73,7 +80,7 @@ public class StartRabbitMojoTest {
         verify(manager).rabbitExtracted();
         verify(manager).isErlangInstalled();
         verify(manager).installErlang();
-        verify(manager).isRabbitRunning();
+        verify(manager, times(2)).isRabbitRunning();
         verify(manager).start(anyString(), anyBoolean());
         Mockito.verifyNoMoreInteractions(manager);
     }
@@ -81,13 +88,13 @@ public class StartRabbitMojoTest {
     @Test
     public void whenRabbitIsRunningStopsFirst() throws Exception {
         // Fixture
-        when(manager.isRabbitRunning()).thenReturn(true);
+        when(manager.isRabbitRunning()).thenReturn(true, false);
         // Execute
         mojo.execute();
         // Assert
         verify(manager).rabbitExtracted();
         verify(manager).isErlangInstalled();
-        verify(manager).isRabbitRunning();
+        verify(manager, times(2)).isRabbitRunning();
         verify(manager).stop();
         verify(manager).start(anyString(), anyBoolean());
         Mockito.verifyNoMoreInteractions(manager);

--- a/src/test/resources/rabbitmq-test-project/pom.xml
+++ b/src/test/resources/rabbitmq-test-project/pom.xml
@@ -2,9 +2,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.iesen</groupId>
+    <groupId>com.github.kohlsj</groupId>
     <artifactId>rabbitmq-maven-plugin-test</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.10</version>
     <packaging>jar</packaging>
 
     <name>RabbitMQ Maven Plugin Test Project</name>
@@ -16,10 +16,14 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.iesen</groupId>
+                <groupId>com.github.kohlsj</groupId>
                 <artifactId>rabbitmq-maven-plugin</artifactId>
-                <version>0.1.0-SNAPSHOT</version>
+                <version>0.1.10</version>
                 <configuration>
+                    <version>3.6.9</version>
+                    <port>5672</port>
+                    <installDirectory>rabbitMq/</installDirectory>
+                    <cleanUpRabbit>true</cleanUpRabbit>
                     <detached>true</detached>
                 </configuration>
             </plugin>

--- a/src/test/resources/rabbitmq-test-project/pom.xml
+++ b/src/test/resources/rabbitmq-test-project/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,7 +29,6 @@
             </plugin>
         </plugins>
     </build>
-
 
 
 </project>


### PR DESCRIPTION
…et installed if it is not installed. Also allow the user to provide the port at which rmq is listening, the version of rmq, whether or not to delete rmq upon stopping it. Whether or not to restart rmq every time the start command is invoked. Also update acceptance and unit tests to reflect the changes. Update readme to reflect changes. Add myself as a developer to the plugin.